### PR TITLE
BE-7 회원가입 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+    ext {
+        queryDslVersion = "4.4.0"
+    }
+    dependencies {
+        classpath("gradle.plugin.com.ewerk.gradle.plugins:querydsl-plugin:1.0.10")
+    }
+}
+
 plugins {
     id 'org.springframework.boot' version '2.7.3'
     id 'io.spring.dependency-management' version '1.0.13.RELEASE'
@@ -7,6 +16,9 @@ plugins {
 group = 'com.hongdaestudy'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
+
+apply plugin: "com.ewerk.gradle.plugins.querydsl"
+
 
 configurations {
     compileOnly {
@@ -19,19 +31,53 @@ repositories {
 }
 
 dependencies {
+    // spring
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation', version: '2.5.3'
+
+    // querydsl
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    implementation 'com.querydsl:querydsl-jpa'
+    implementation 'com.querydsl:querydsl-apt'
+
+    // jwt
+    compileOnly 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5', 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    runtimeOnly 'mysql:mysql-connector-java'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+
+    testImplementation('org.springframework.boot:spring-boot-starter-test') {
+        exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+    }
 }
 
 tasks.named('test') {
     useJUnitPlatform()
 }
 
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    library = "com.querydsl:querydsl-apt"
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+
 sourceSets {
+    main {
+        java {
+            srcDirs = ['src/main/java', querydslDir]
+        }
+    }
     integrationTest {
         java.srcDir "$projectDir/src/integration-test/java"
         resources.srcDir "$projectDir/src/integration-test/resources"
@@ -54,6 +100,18 @@ configurations {
     systemTestImplementation.extendsFrom implementation
     systemTestImplementation.extendsFrom testImplementation
     systemTestRuntimeOnly.extendsFrom testRuntimeOnly
+}
+
+compileQuerydsl{
+    options.annotationProcessorPath = configurations.querydsl
+}
+
+configurations {
+    querydsl.extendsFrom compileClasspath
+}
+
+clean {
+    delete file('src/main/generated')
 }
 
 task integrationTest(type: Test) {

--- a/src/main/java/com/hongdaestudy/recipebackend/common/BaseEntity.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/common/BaseEntity.java
@@ -1,0 +1,6 @@
+package com.hongdaestudy.recipebackend.common;
+
+import org.springframework.data.domain.AbstractAggregateRoot;
+
+public abstract class BaseEntity<ENTITY, ID> extends AbstractAggregateRoot<BaseEntity<ENTITY, ID>> {
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/common/BaseTimeEntity.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/common/BaseTimeEntity.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public abstract class BaseTimeEntity {
+public abstract class BaseTimeEntity<ENTITY, ID>  extends BaseEntity <ENTITY, ID>{
 
   @CreatedDate
   private LocalDateTime createdAt;

--- a/src/main/java/com/hongdaestudy/recipebackend/config/error/ErrorCode.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/config/error/ErrorCode.java
@@ -1,0 +1,28 @@
+package com.hongdaestudy.recipebackend.config.error;
+
+public enum ErrorCode {
+    HANDLE_ACCESS_DENIED(403, "C_001", "권한이 없습니다."),
+    MEMBER_NOT_FOUND(400, "C_002", "사용자 정보를 찾을 수 없습니다.");
+
+    private final String code;
+    private final String message;
+    private final int status;
+
+    ErrorCode(int status, String code, String message) {
+        this.status = status;
+        this.message = message;
+        this.code = code;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/config/error/ErrorResponse.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/config/error/ErrorResponse.java
@@ -1,0 +1,25 @@
+package com.hongdaestudy.recipebackend.config.error;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+    private String message;
+    private String code;
+    private String timestamp;
+
+    public ErrorResponse(String message, String code) {
+        this.message = message;
+        this.code = code;
+        this.timestamp = LocalDateTime.now().toString();
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getMessage(), errorCode.getCode());
+    }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/config/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/config/error/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.hongdaestudy.recipebackend.config.error;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.nio.file.AccessDeniedException;
+
+import static com.hongdaestudy.recipebackend.config.error.ErrorCode.HANDLE_ACCESS_DENIED;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(AccessDeniedException.class)
+    protected ResponseEntity<ErrorResponse>  handleAccessDeniedException(AccessDeniedException e) {
+        log.error("handleAccessDeniedException", e);
+        final ErrorResponse response = ErrorResponse.of(HANDLE_ACCESS_DENIED);
+        return new ResponseEntity<>(response, HttpStatus.valueOf(HANDLE_ACCESS_DENIED.getStatus()));
+    }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/config/error/exception/UserTokenNotFoundException.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/config/error/exception/UserTokenNotFoundException.java
@@ -1,0 +1,9 @@
+package com.hongdaestudy.recipebackend.config.error.exception;
+
+public class UserTokenNotFoundException extends RuntimeException {
+
+    public UserTokenNotFoundException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/config/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,39 @@
+package com.hongdaestudy.recipebackend.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hongdaestudy.recipebackend.config.error.ErrorCode;
+import com.hongdaestudy.recipebackend.config.error.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+
+@Component
+@Slf4j
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    ErrorResponse exceptionResponse = ErrorResponse.of(ErrorCode.HANDLE_ACCESS_DENIED);
+
+    @Override
+    public void commence(HttpServletRequest httpServletRequest,
+                         HttpServletResponse httpServletResponse,
+                         AuthenticationException e) throws IOException, ServletException {
+
+        httpServletResponse.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        httpServletResponse.setStatus(HttpStatus.UNAUTHORIZED.value());
+
+        try (OutputStream os = httpServletResponse.getOutputStream()) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.writeValue(os, exceptionResponse);
+            os.flush();
+        }
+    }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/config/security/JwtTokenGenerator.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/config/security/JwtTokenGenerator.java
@@ -1,0 +1,69 @@
+package com.hongdaestudy.recipebackend.config.security;
+
+import com.hongdaestudy.recipebackend.config.error.exception.UserTokenNotFoundException;
+import com.hongdaestudy.recipebackend.user.domain.*;
+import com.hongdaestudy.recipebackend.user.repository.BearerTokenRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import lombok.NoArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtTokenGenerator {
+    private final Long accessTokenValidSeconds;
+    private final Long refreshTokenValidSeconds;
+    private final String jwtSecret;
+    private final Key key;
+    private final BearerTokenRepository bearerTokenRepository;
+
+    public JwtTokenGenerator(@Value("${jwt.access-token-valid-seconds}") Long accessTokenValidSeconds,
+                             @Value("${jwt.refresh-token-valid-seconds}") Long refreshTokenValidSeconds,
+                             @Value("${jwt.secret}")  String jwtSecret,
+                             BearerTokenRepository bearerTokenRepository) {
+        this.accessTokenValidSeconds = accessTokenValidSeconds;
+        this.refreshTokenValidSeconds = refreshTokenValidSeconds;
+        this.jwtSecret = jwtSecret;
+        this.key = Keys.hmacShaKeyFor(jwtSecret.getBytes());
+        this.bearerTokenRepository = bearerTokenRepository;
+    }
+
+    public Tokens create(User user, UserProfile userProfile) {
+        long nowInMilliseconds = new Date().getTime();
+        String accessToken = createAccessToken(String.valueOf(user.getId()), String.valueOf(userProfile.getId()), "ROLE_USER", new Date(nowInMilliseconds + accessTokenValidSeconds * 1000));
+        String refreshToken = createRefreshToken(new Date(nowInMilliseconds + refreshTokenValidSeconds * 1000));
+        bearerTokenRepository.save(new BearerToken(user.getId(), userProfile.getId(), refreshToken, accessToken));
+        return new Tokens(accessToken, refreshToken);
+    }
+
+    public Tokens exchangeAccessToken(User user,UserProfile profile, String accessToken) {
+        BearerToken token = bearerTokenRepository.findFirstByAccessToken(accessToken)
+                .orElseThrow(() -> new UserTokenNotFoundException("accessToken not found. token : " + accessToken));
+        long nowInMilliseconds = new Date().getTime();
+        String changedAccessToken = createAccessToken(String.valueOf(user.getId()), String.valueOf(profile.getId()), "ROLE_USER", new Date(nowInMilliseconds + accessTokenValidSeconds * 1000));
+        token.exchangeAccessToken(changedAccessToken);
+        bearerTokenRepository.save(token);
+        return new Tokens(changedAccessToken, token.getRefreshToken());
+    }
+
+    private String createAccessToken(String userId, String userProfileId, String role, Date expiry) {
+        Claims claims = Jwts.claims().setSubject(userId).setExpiration(expiry).setIssuedAt(new Date());
+        claims.put("role", role);
+        claims.put("userProfileId", userProfileId);
+        return Jwts.builder()
+                .setClaims(claims)
+                .signWith(key)
+                .compact();
+    }
+
+    private String createRefreshToken(Date expiry) {
+        return Jwts.builder()
+                .setClaims(Jwts.claims().setExpiration(expiry).setIssuedAt(new Date()))
+                .signWith(key)
+                .compact();
+    }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/config/security/JwtTokenProvider.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/config/security/JwtTokenProvider.java
@@ -1,0 +1,44 @@
+package com.hongdaestudy.recipebackend.config.security;
+
+import io.jsonwebtoken.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider { // JWT 토큰 생성 및 검증 모듈
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @PostConstruct
+    protected void init() {
+        secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+    }
+
+    // Request의 Header에서 token파싱
+    public String resolveToken(HttpServletRequest request) {
+        return request.getHeader("Authorization");
+    }
+
+    // Jwt 토큰의 유효성 + 만료일자 확인
+    public boolean validateToken(String jwtToken) {
+        try{
+            Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(jwtToken.substring("Bearer ".length()));
+            return !claims.getBody().getExpiration().before(new Date());// 만료시간이 현재시간보다 전인지 확인
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/config/security/SecurityConfig.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/config/security/SecurityConfig.java
@@ -1,0 +1,38 @@
+package com.hongdaestudy.recipebackend.config.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .httpBasic().disable()
+                .cors().disable()
+                .formLogin().disable()
+                .csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                    .exceptionHandling()
+                    .authenticationEntryPoint(authenticationEntryPoint)
+                .and()
+                    .authorizeRequests()
+                    .antMatchers("/", "/**").permitAll()
+                    .anyRequest().permitAll();
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/application/UserService.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/application/UserService.java
@@ -1,0 +1,28 @@
+package com.hongdaestudy.recipebackend.user.application;
+
+import com.hongdaestudy.recipebackend.config.security.JwtTokenGenerator;
+import com.hongdaestudy.recipebackend.user.application.in.UserRegisterCommand;
+import com.hongdaestudy.recipebackend.user.application.out.UserRegisterCommandResult;
+import com.hongdaestudy.recipebackend.user.domain.*;
+import com.hongdaestudy.recipebackend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+    private final JwtTokenGenerator tokenGenerator;
+
+    @Transactional
+    public UserRegisterCommandResult create(UserRegisterCommand request) {
+        String password = passwordEncoder.encode(request.getPassword());
+        User user = new User(request.getEmail(), password);
+        userRepository.save(user);
+        user = userRepository.findById(user.getId()).orElseThrow();
+        return UserRegisterCommandResult.from(user, tokenGenerator.create(user, user.getUserProfile()));
+    }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/application/in/UserRegisterCommand.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/application/in/UserRegisterCommand.java
@@ -1,0 +1,14 @@
+package com.hongdaestudy.recipebackend.user.application.in;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+public class UserRegisterCommand {
+    @NotBlank(message = "이메일을 입력해주세요.")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/application/out/UserRegisterCommandResult.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/application/out/UserRegisterCommandResult.java
@@ -1,0 +1,18 @@
+package com.hongdaestudy.recipebackend.user.application.out;
+
+import com.hongdaestudy.recipebackend.user.domain.Tokens;
+import com.hongdaestudy.recipebackend.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserRegisterCommandResult {
+    private long userId;
+    private String accessToken;
+    private String refreshToken;
+
+    public static UserRegisterCommandResult from(User user, Tokens tokens){
+        return new UserRegisterCommandResult(user.getId(), tokens.getAccessToken(), tokens.getRefreshToken());
+    }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/domain/BearerToken.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/domain/BearerToken.java
@@ -1,0 +1,39 @@
+package com.hongdaestudy.recipebackend.user.domain;
+
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BearerToken {
+    public static final String ACCESS_TOKEN_CACHE_KEY = "access.token";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bearer_token_id")
+    private Long id;
+
+    private Long userId;
+
+    private Long userProfileId;
+
+    private String refreshToken;
+
+    private String accessToken;
+
+    public BearerToken(Long userId, Long userProfileId, String refreshToken, String accessToken) {
+        this.userId = userId;
+        this.userProfileId = userProfileId;
+        this.refreshToken = refreshToken;
+        this.accessToken = accessToken;
+    }
+
+    public void exchangeAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/domain/CreateUserProfileHandler.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/domain/CreateUserProfileHandler.java
@@ -1,0 +1,25 @@
+package com.hongdaestudy.recipebackend.user.domain;
+
+import com.hongdaestudy.recipebackend.user.repository.UserProfileRepository;
+import com.hongdaestudy.recipebackend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+public class CreateUserProfileHandler {
+    private final UserProfileRepository userProfileRepository;
+    private final UserRepository userRepository;
+
+    @EventListener
+    @Transactional
+    public void createFirstUserProfile(UserCreatedEvent event) {
+        User user = event.getUser();
+        UserProfile userProfile = new UserProfile(user.getId());
+        userProfileRepository.save(userProfile);
+        user.changeUserProfile(userProfile);
+        userRepository.updateUserProfileId(user.getId(), userProfile.getId());
+    }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/domain/Tokens.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/domain/Tokens.java
@@ -1,0 +1,13 @@
+package com.hongdaestudy.recipebackend.user.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Tokens {
+    String accessToken;
+    String refreshToken;
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/domain/User.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/domain/User.java
@@ -29,6 +29,7 @@ public class User extends BaseTimeEntity<User, Long> {
     public User(String email, String password) {
         this.email = email;
         this.password = password;
+        registerEvent(new UserCreatedEvent(this));
     }
 
     public void changeUserProfile(UserProfile userProfile) {

--- a/src/main/java/com/hongdaestudy/recipebackend/user/domain/User.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/domain/User.java
@@ -1,0 +1,37 @@
+package com.hongdaestudy.recipebackend.user.domain;
+
+import com.hongdaestudy.recipebackend.common.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseTimeEntity<User, Long> {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_profile_id")
+    private UserProfile userProfile;
+
+    private String email;
+
+    private String password;
+
+    // todo: validate
+    public User(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+
+    public void changeUserProfile(UserProfile userProfile) {
+        this.userProfile = userProfile;
+    }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/domain/UserCreatedEvent.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/domain/UserCreatedEvent.java
@@ -1,0 +1,15 @@
+package com.hongdaestudy.recipebackend.user.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserCreatedEvent {
+    User user;
+
+    public UserCreatedEvent(User user){
+        this.user = user;
+    }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/domain/UserProfile.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/domain/UserProfile.java
@@ -1,0 +1,31 @@
+package com.hongdaestudy.recipebackend.user.domain;
+
+import com.hongdaestudy.recipebackend.common.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserProfile extends BaseTimeEntity<UserProfile, Long> {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_profile_id")
+    private Long id;
+
+    private Long userId;
+
+    private String nickname;
+
+    private Long profileFileId;
+
+    private Long backgroundFileId;
+
+    public UserProfile(long userId) {
+        this.userId = userId;
+    }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/presentation/UserCommandController.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/presentation/UserCommandController.java
@@ -1,0 +1,28 @@
+package com.hongdaestudy.recipebackend.user.presentation;
+
+import com.hongdaestudy.recipebackend.user.application.UserService;
+import com.hongdaestudy.recipebackend.user.application.in.UserRegisterCommand;
+import com.hongdaestudy.recipebackend.user.application.out.UserRegisterCommandResult;
+import com.hongdaestudy.recipebackend.user.domain.Tokens;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class UserCommandController {
+
+    private final UserService userService;
+
+    @PostMapping("/join")
+    public ResponseEntity<UserRegisterCommandResult> create(@RequestBody UserRegisterCommand request) { ;
+        return ResponseEntity.ok(userService.create(request));
+    }
+
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/repository/BearerTokenRepository.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/repository/BearerTokenRepository.java
@@ -1,0 +1,11 @@
+package com.hongdaestudy.recipebackend.user.repository;
+
+import com.hongdaestudy.recipebackend.user.domain.BearerToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BearerTokenRepository extends JpaRepository<BearerToken, Long> {
+    Optional<BearerToken> findFirstByRefreshToken(String refreshToken);
+    Optional<BearerToken> findFirstByAccessToken(String accessToken);
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/repository/UserProfileRepository.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/repository/UserProfileRepository.java
@@ -1,0 +1,9 @@
+package com.hongdaestudy.recipebackend.user.repository;
+
+import com.hongdaestudy.recipebackend.user.domain.UserProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/repository/UserRepository.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.hongdaestudy.recipebackend.user.repository;
+
+import com.hongdaestudy.recipebackend.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    @Modifying
+    @Query(nativeQuery = true, value = "update user set user_profile_id = :userProfileId where user_id = :userId")
+    void updateUserProfileId(Long userId, Long userProfileId);
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,3 +26,7 @@ logging.level:
   org.hibernate.SQL: debug
   org.hibernate.type: trace
 
+jwt:
+  secret: aG9uZ2RhZXN0dWR5MTAwMHJlY2VpcGViYWNrZW5kdG9rZW4=
+  access-token-valid-seconds: 7200 # 2 hour
+  refresh-token-valid-seconds: 604800 # 7 day


### PR DESCRIPTION
[comment]: <> "PR 제목은 다음과 같은 형태로 작성하고, 리뷰어에는 팀원 전체를 할당합니다."
[comment]: <> "{Jira-Issue-number} {한 줄 축약 내용 또는 티켓 제목 원형 그대로 이용}"



## 작업 개요

<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->

- 회원가입 API 구현
  - 이메일
  - 비밀번호


## 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경


## 작업 상세 내용

<!--
  ex) 네 발 짐승 클래스에 `크앙` 함수 추가
-->

### 회원가입 기본 로직

1. 이메일, 비밀번호 입력
   - todo 
     - 이메일 중복 validation -> 별도 API 빼야할듯?
     - 이메일 인증 API 구현
2. access token, refresh token 발급
   - 액세스토큰 
     - 기간 : 2시간
     - 들어가는 정보
       - 권한
       - user id
       - user profile id
       - 기간
   - 리프레쉬 
     - 기간 : 일주일
3. user, user profile 데이터 생성
   - user profile 초기 데이터는 user id만 들어감


## 생각해볼 문제

<!--
  ex) wav 파일을 매번 입력하기 귀찮겠다.
-->

- 테스트 코드 작성...안했습니다 다음 구현 때 해놓겠습니다 ^_ㅠ
- API 명세 작성을 위해.. 포스트맨(제일 간단) 혹은 ,,,스웨거(코드가 더러워짐),, 혹은 rest docs(귀찮) 사용해볼까요 ㅎㅎ

  
## 완료한 테스트

<!--
  ex) 로그인 API가 정상적으로 동작하는지 확인
-->

- 회원 정보가 등록되는지 확인
- 기댓값에 따라 repsonse 되는지 확인

```json
{
    "userId": 1,
    "accessToken": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiIxIiwiZXhwIjoxNjY0MzA1Njc4LCJpYXQiOjE2NjQyOTg0NzgsInJvbGUiOiJST0xFX1VTRVIiLCJ1c2VyUHJvZmlsZUlkIjoiMSJ9.wnHaLOce0ZZ4ntNALyjFU8yYVZVmf1Wa8lIGtHmXRvFQNt0L_5Fm_yZ6gUm-r5ro",
    "refreshToken": "eyJhbGciOiJIUzM4NCJ9.eyJleHAiOjE2NjQ5MDMyNzgsImlhdCI6MTY2NDI5ODQ3OH0.70W5k8u-7AvSn_xl_VlRzDDmJqOw7pknoAnY2daxj_zwjOuWBtu0z8y_uFohT5Yi"
}
```

