### PR TITLE
BE 11/BE 35 댓글 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/hongdaestudy/recipebackend/comment/application/RegisterCommentService.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/comment/application/RegisterCommentService.java
@@ -4,33 +4,44 @@ import com.hongdaestudy.recipebackend.comment.application.in.RegisterCommentComm
 import com.hongdaestudy.recipebackend.comment.application.out.RegisterCommentCommandResult;
 import com.hongdaestudy.recipebackend.comment.domain.Comment;
 import com.hongdaestudy.recipebackend.comment.domain.repository.CommentRepository;
+import com.hongdaestudy.recipebackend.config.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class RegisterCommentService {
-    private final CommentRepository commentRepository;
+  private final CommentRepository commentRepository;
 
-    @Transactional
-    public RegisterCommentCommandResult registerComment(RegisterCommentCommand registerRecipeCommentCommand) {
-        Comment comment = from(registerRecipeCommentCommand);
-        commentRepository.save(comment);
+  @Transactional
+  public RegisterCommentCommandResult registerComment(RegisterCommentCommand registerRecipeCommentCommand) throws Exception {
 
-        return new RegisterCommentCommandResult(comment.getId());
+    Comment comment = from(registerRecipeCommentCommand);
+    Comment saved = commentRepository.save(comment);
+
+    return new RegisterCommentCommandResult(saved.getId());
+  }
+
+  private Comment from(RegisterCommentCommand registerCommentCommand) throws Exception {
+
+    Optional<Comment> parent = Optional.empty();
+    // 자식댓글인 경우, 부모 댓글 검증
+    if (registerCommentCommand.getParentCommentId() != null) {
+      parent = commentRepository.findById(registerCommentCommand.getParentCommentId());
+      parent.orElseThrow(() -> new Exception(ErrorCode.COMMENT_NOT_FOUND.getMessage()));
     }
-
-    private Comment from(RegisterCommentCommand registerCommentCommand) {
-        return Comment.create(
-                registerCommentCommand.getRecipeId(),
-                registerCommentCommand.getUserId(),
-                registerCommentCommand.getContent(),
-                registerCommentCommand.getParentCommentId(),
-                registerCommentCommand.getLevel(),
-                registerCommentCommand.getSort(),
-                registerCommentCommand.getScore(),
-                registerCommentCommand.getPhotoFileId());
-    }
+    return Comment.create(
+        registerCommentCommand.getRecipeId(),
+        registerCommentCommand.getUserId(),
+        registerCommentCommand.getContent(),
+        parent,
+        registerCommentCommand.getLevel(),
+        registerCommentCommand.getSort(),
+        registerCommentCommand.getScore(),
+        registerCommentCommand.getPhotoFileId());
+  }
 
 }

--- a/src/main/java/com/hongdaestudy/recipebackend/comment/application/RetrieveCommentService.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/comment/application/RetrieveCommentService.java
@@ -1,0 +1,39 @@
+package com.hongdaestudy.recipebackend.comment.application;
+
+import com.hongdaestudy.recipebackend.comment.application.in.RetrieveCommentCommand;
+import com.hongdaestudy.recipebackend.comment.application.out.RetrieveCommentCommandResult;
+import com.hongdaestudy.recipebackend.comment.domain.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class RetrieveCommentService {
+  private final CommentRepository commentRepository;
+
+  @Transactional
+  public List<RetrieveCommentCommandResult> retrieveComment(RetrieveCommentCommand retrieveCommentCommand) {
+
+    List<RetrieveCommentCommandResult> commentList = commentRepository.findAllByRecipeId(retrieveCommentCommand.getRecipeId());
+
+    return convertNestedStructure(commentList);
+  }
+
+  private List<RetrieveCommentCommandResult> convertNestedStructure(List<RetrieveCommentCommandResult> comments) {
+    List<RetrieveCommentCommandResult> result = new ArrayList<>();
+    Map<Long, RetrieveCommentCommandResult> map = new HashMap<>();
+    comments.stream().forEach(comment -> {
+      map.put(comment.getId(), comment);
+      if (comment.getParentCommentId() != null) map.get(comment.getParentCommentId()).getChildren().add(comment);
+      else result.add(comment);
+    });
+    return result;
+  }
+
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/comment/application/in/RetrieveCommentCommand.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/comment/application/in/RetrieveCommentCommand.java
@@ -1,0 +1,23 @@
+package com.hongdaestudy.recipebackend.comment.application.in;
+
+import com.hongdaestudy.recipebackend.common.SelfValidating;
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+public class RetrieveCommentCommand extends SelfValidating<RetrieveCommentCommand> {
+
+  @NotNull
+  private long recipeId;
+
+  private long userId;
+
+  public RetrieveCommentCommand(long recipeId, long userId) {
+
+    this.recipeId = recipeId;
+    this.userId = userId;
+
+    this.validateSelf();
+  }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/comment/application/out/RetrieveCommentCommandResult.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/comment/application/out/RetrieveCommentCommandResult.java
@@ -1,0 +1,60 @@
+package com.hongdaestudy.recipebackend.comment.application.out;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RetrieveCommentCommandResult {
+  @NotNull
+  private Long id;
+
+  @NotNull
+  private Long recipeId;
+
+  private Long userId;
+
+  private String userNickname;
+
+  private Long profileFileId;
+
+  private String content;
+
+  private Long parentCommentId;
+
+  @NotNull
+  private Integer level;
+
+  private Integer sort;
+
+  private String score;
+
+  private Long photoFileId;
+
+  private List<RetrieveCommentCommandResult> children;
+
+  @QueryProjection
+  public RetrieveCommentCommandResult(Long id, Long recipeId, Long userId, String userNickname, Long profileFileId, String content, Long parentCommentId, Integer level, Integer sort, String score, Long photoFileId) {
+    this.id = id;
+    this.recipeId = recipeId;
+    this.userId = userId;
+    this.userNickname = userNickname;
+    this.profileFileId = profileFileId;
+    this.content = content;
+    this.parentCommentId = parentCommentId;
+    this.level = level;
+    this.sort = sort;
+    this.score = score;
+    this.photoFileId = photoFileId;
+    this.children = new ArrayList<>();
+  }
+
+
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/comment/domain/Comment.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/comment/domain/Comment.java
@@ -1,7 +1,6 @@
 package com.hongdaestudy.recipebackend.comment.domain;
 
 import com.hongdaestudy.recipebackend.common.BaseTimeEntity;
-import com.sun.istack.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +8,9 @@ import lombok.ToString;
 import org.hibernate.Hibernate;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 import java.util.Objects;
+import java.util.Optional;
 
 @Table(name = "comment")
 @Entity
@@ -23,14 +24,16 @@ public class Comment extends BaseTimeEntity {
   private Long id;
 
   @NotNull
-  private long recipeId;
+  private Long recipeId;
 
   @NotNull
-  private long userId;
+  private Long userId;
 
   private String content;
 
-  private Long parentCommentId;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "parent_comment_id")
+  private Comment parent;
 
   @NotNull
   private int level;
@@ -41,11 +44,12 @@ public class Comment extends BaseTimeEntity {
 
   private Long photoFileId;
 
+
   public static Comment create(
       Long recipeId
       , Long userId
       , String content
-      , Long parentCommentId
+      , Optional<Comment> parent
       , int level
       , int sort
       , String score
@@ -55,12 +59,13 @@ public class Comment extends BaseTimeEntity {
     comment.recipeId = recipeId;
     comment.userId = userId;
     comment.content = content;
-    comment.parentCommentId = parentCommentId;
+    if (parent.isPresent()) {
+      comment.parent = parent.get();
+    }
     comment.level = level;
     comment.sort = sort;
     comment.score = score;
     comment.photoFileId = photoFileId;
-
     return comment;
   }
 

--- a/src/main/java/com/hongdaestudy/recipebackend/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/comment/domain/repository/CommentRepository.java
@@ -4,7 +4,7 @@ package com.hongdaestudy.recipebackend.comment.domain.repository;
 import com.hongdaestudy.recipebackend.comment.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
 
 }

--- a/src/main/java/com/hongdaestudy/recipebackend/comment/domain/repository/CommentRepositoryCustom.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/comment/domain/repository/CommentRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.hongdaestudy.recipebackend.comment.domain.repository;
+
+import com.hongdaestudy.recipebackend.comment.application.out.RetrieveCommentCommandResult;
+
+import java.util.List;
+
+public interface CommentRepositoryCustom {
+  List<RetrieveCommentCommandResult> findAllByRecipeId(long recipeId);
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/comment/domain/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/comment/domain/repository/CommentRepositoryImpl.java
@@ -1,0 +1,57 @@
+package com.hongdaestudy.recipebackend.comment.domain.repository;
+
+import com.hongdaestudy.recipebackend.comment.application.out.RetrieveCommentCommandResult;
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.hongdaestudy.recipebackend.comment.domain.QComment.comment;
+import static com.hongdaestudy.recipebackend.user.domain.QUser.user;
+
+
+@Repository
+public class CommentRepositoryImpl implements CommentRepositoryCustom {
+  private final JPAQueryFactory queryFactory;
+
+  public CommentRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+    this.queryFactory = jpaQueryFactory;
+  }
+
+  @Override
+  public List<RetrieveCommentCommandResult> findAllByRecipeId(long recipeId) {
+
+    List<RetrieveCommentCommandResult> comments = queryFactory.select(Projections.constructor(RetrieveCommentCommandResult.class
+            , comment.id.as("id")
+            , comment.recipeId.as("recipeId")
+            , comment.userId.as("userId")
+            , ExpressionUtils.as(
+                JPAExpressions.select(user.userProfile.nickname)
+                    .from(user)
+                    .where(user.id.eq(comment.userId)),
+                "userNickname")
+            , ExpressionUtils.as(
+                JPAExpressions.select(user.userProfile.profileFileId)
+                    .from(user)
+                    .where(user.id.eq(comment.userId)),
+                "profileFileId")
+            , comment.content.as("content")
+            , comment.parent.id.as("parentCommentId")
+            , comment.level.as("level")
+            , comment.sort.as("sort")
+            , comment.score.as("score")
+            , comment.photoFileId.as("photoFileId")))
+        .from(comment)
+        .leftJoin(comment.parent)
+        .where(comment.recipeId.eq(recipeId))
+        .orderBy(
+            comment.parent.id.asc().nullsFirst(),
+            comment.sort.asc()
+        ).fetch();
+
+    return comments;
+  }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/comment/presentation/CommentCommandController.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/comment/presentation/CommentCommandController.java
@@ -1,26 +1,41 @@
 package com.hongdaestudy.recipebackend.comment.presentation;
 
 import com.hongdaestudy.recipebackend.comment.application.RegisterCommentService;
+import com.hongdaestudy.recipebackend.comment.application.RetrieveCommentService;
 import com.hongdaestudy.recipebackend.comment.application.in.RegisterCommentCommand;
+import com.hongdaestudy.recipebackend.comment.application.in.RetrieveCommentCommand;
 import com.hongdaestudy.recipebackend.comment.application.out.RegisterCommentCommandResult;
+import com.hongdaestudy.recipebackend.comment.application.out.RetrieveCommentCommandResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 public class CommentCommandController {
 
-    private final RegisterCommentService registerCommentService;
+  private final RegisterCommentService registerCommentService;
+  private final RetrieveCommentService retrieveCommentService;
 
-    @PostMapping("/comment")
-    public ResponseEntity<RegisterCommentCommandResult> registerComment(@RequestBody RegisterCommentCommand registerCommentCommand) {
+  @PostMapping("/comment")
+  public ResponseEntity<RegisterCommentCommandResult> registerComment(@RequestBody RegisterCommentCommand registerCommentCommand) throws Exception {
 
-        RegisterCommentCommandResult result = registerCommentService.registerComment(registerCommentCommand);
+    RegisterCommentCommandResult result = registerCommentService.registerComment(registerCommentCommand);
 
-        return ResponseEntity.ok(result);
-    }
+    return ResponseEntity.ok(result);
+  }
+
+  @GetMapping("/comments")
+  public ResponseEntity<List<RetrieveCommentCommandResult>> retrieveComment(@RequestBody RetrieveCommentCommand retrieveCommentCommand) {
+
+    List<RetrieveCommentCommandResult> result = retrieveCommentService.retrieveComment(retrieveCommentCommand);
+
+    return ResponseEntity.ok(result);
+  }
 
 }

--- a/src/main/java/com/hongdaestudy/recipebackend/config/JpaConfig.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/config/JpaConfig.java
@@ -1,9 +1,23 @@
 package com.hongdaestudy.recipebackend.config;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 
 @Configuration
 @EnableJpaAuditing
 public class JpaConfig {
+  
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+
 }

--- a/src/main/java/com/hongdaestudy/recipebackend/config/error/ErrorCode.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/config/error/ErrorCode.java
@@ -1,28 +1,32 @@
 package com.hongdaestudy.recipebackend.config.error;
 
 public enum ErrorCode {
-    HANDLE_ACCESS_DENIED(403, "C_001", "권한이 없습니다."),
-    MEMBER_NOT_FOUND(400, "C_002", "사용자 정보를 찾을 수 없습니다.");
+  HANDLE_ACCESS_DENIED(403, "C_001", "권한이 없습니다."),
+  MEMBER_NOT_FOUND(400, "C_002", "사용자 정보를 찾을 수 없습니다."),
 
-    private final String code;
-    private final String message;
-    private final int status;
+  SCRAP_DUPLICATION(409, "C_003", "이미 스크랩된 레시피 입니다."),
+  COMMENT_NOT_FOUND(400, "C_004", "부모 댓글을 찾을 수 없습니다.");
 
-    ErrorCode(int status, String code, String message) {
-        this.status = status;
-        this.message = message;
-        this.code = code;
-    }
 
-    public String getMessage() {
-        return this.message;
-    }
+  private final String code;
+  private final String message;
+  private final int status;
 
-    public String getCode() {
-        return code;
-    }
+  ErrorCode(int status, String code, String message) {
+    this.status = status;
+    this.message = message;
+    this.code = code;
+  }
 
-    public int getStatus() {
-        return status;
-    }
+  public String getMessage() {
+    return this.message;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public int getStatus() {
+    return status;
+  }
 }

--- a/src/test/java/com/hongdaestudy/recipebackend/comment/application/RegisterCommentServiceTest.java
+++ b/src/test/java/com/hongdaestudy/recipebackend/comment/application/RegisterCommentServiceTest.java
@@ -38,13 +38,38 @@ public class RegisterCommentServiceTest {
 
       @Test
       @DisplayName("주어진 객체를 저장하고, 저장된 객체를 리턴한다")
-      void it_saves_obj_and_returns_a_saved_obj() {
+      void it_saves_obj_and_returns_a_saved_obj() throws Exception {
 
         RegisterCommentCommandResult result = registerCommentService.registerComment(command);
         Assertions.assertNotNull(result.getId(), "저장된 객체는 아이디가 추가되어 있다");
 
         Optional<Comment> saved = repository.findById(result.getId());
         Assertions.assertEquals(saved.get().getContent(), givenContent);
+      }
+    }
+
+    @Nested
+    @DisplayName("등록 객체가 주어지면")
+    class Context_with_comments {
+      RegisterCommentCommand parent = new RegisterCommentCommand(1L, 1L, givenContent, null, 0, 1, "4.5", null);
+      RegisterCommentCommand child1 = new RegisterCommentCommand(1L, 2L, givenContent, 1L, 1, 1, "4.0", null);
+      RegisterCommentCommand child2 = new RegisterCommentCommand(1L, 3L, givenContent, 1L, 1, 2, "3.0", null);
+      RegisterCommentCommand child3 = new RegisterCommentCommand(1L, 4L, givenContent, 2L, 2, 1, "2.0", null);
+
+      @Test
+      @DisplayName("주어진 객체를 저장하고, 저장된 객체를 리턴한다")
+      void it_saves_obj_and_returns_a_saved_obj() throws Exception {
+
+        RegisterCommentCommandResult result1 = registerCommentService.registerComment(parent);
+        Assertions.assertNotNull(result1.getId(), "저장된 객체는 아이디가 추가되어 있다");
+
+        RegisterCommentCommandResult result2 = registerCommentService.registerComment(child1);
+        Assertions.assertNotNull(result2.getId(), "저장된 객체는 아이디가 추가되어 있다");
+        RegisterCommentCommandResult result3 = registerCommentService.registerComment(child2);
+        Assertions.assertNotNull(result3.getId(), "저장된 객체는 아이디가 추가되어 있다");
+        RegisterCommentCommandResult result4 = registerCommentService.registerComment(child3);
+        Assertions.assertNotNull(result4.getId(), "저장된 객체는 아이디가 추가되어 있다");
+
       }
     }
   }

--- a/src/test/java/com/hongdaestudy/recipebackend/comment/domain/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/hongdaestudy/recipebackend/comment/domain/repository/CommentRepositoryTest.java
@@ -1,18 +1,28 @@
 package com.hongdaestudy.recipebackend.comment.domain.repository;
 
+import com.hongdaestudy.recipebackend.comment.application.out.RetrieveCommentCommandResult;
 import com.hongdaestudy.recipebackend.comment.domain.Comment;
+import com.hongdaestudy.recipebackend.config.TestConfig;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.persistence.EntityManager;
+import java.util.List;
 
 @ExtendWith(SpringExtension.class)
 @DataJpaTest
+@Import(TestConfig.class)
 @DisplayName("CommentRepository")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class CommentRepositoryTest {
+
+  @Autowired
+  private EntityManager entityManager;
 
   @Autowired
   CommentRepository repository;
@@ -20,11 +30,11 @@ class CommentRepositoryTest {
 
   @Nested
   @DisplayName("save 메소드")
-  class Describe_save {
+  class Describe_save1 {
 
     @BeforeEach
     void prepare() {
-      repository.deleteAll();
+      //repository.deleteAll();
     }
 
     @Nested
@@ -34,7 +44,7 @@ class CommentRepositoryTest {
           1L
           , 1L
           , givenContent
-          , null
+          , java.util.Optional.empty()
           , 0
           , 0
           , "4.5"
@@ -49,8 +59,62 @@ class CommentRepositoryTest {
         final Comment saved = repository.save(givenComment);
 
         Assertions.assertNotNull(saved.getId(), "저장된 객체는 아이디가 추가되어 있다");
-        Assertions.assertEquals(saved.getContent(), givenContent);
+        Assertions.assertEquals(saved.getContent(), givenContent, "저장된 객체가 동일합니다.");
       }
     }
+  }
+  @Nested
+  @DisplayName("findAllByRecipeId 메소드")
+  class Describe_findAllByRecipeId {
+
+    @BeforeEach
+    void prepare() {
+      //repository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("댓글 객체리스트가 주어지면")
+    class Context_with_comments {
+      Comment givenParent = Comment.create(2L, 1L, givenContent, java.util.Optional.empty(), 0, 0, "1.0", 1L);
+      Comment givenChild = Comment.create(2L, 1L, givenContent, java.util.Optional.of(givenParent), 1, 0, "2.0", 2L);
+      Comment givenChild2 = Comment.create(2L, 1L, givenContent, java.util.Optional.ofNullable(givenParent), 1, 1, "3.0", 3L);
+      Comment givenChild3 = Comment.create(2L, 1L, givenContent, java.util.Optional.ofNullable(givenChild), 2, 1, "4.0", 4L);
+
+      @Test
+      @DisplayName("주어진 객체리스트를 저장하고, 저장된 객체를 리턴한다")
+      void it_saves_obj_and_returns_a_saved_obj() {
+        repository.save(givenParent);
+        repository.save(givenChild);
+        repository.save(givenChild2);
+        repository.save(givenChild3);
+
+        List<RetrieveCommentCommandResult> list = repository.findAllByRecipeId(2L);
+
+        Assertions.assertEquals(list.stream().count(), 4, "객체 조회 성공");
+
+        for (RetrieveCommentCommandResult comment : list) {
+          compareComment(list.get(0), givenParent);
+          compareComment(list.get(1), givenChild);
+          compareComment(list.get(2), givenChild2);
+          compareComment(list.get(3), givenChild3);
+        }
+      }
+    }
+  }
+
+  static void compareComment(RetrieveCommentCommandResult retrieve, Comment saved) {
+    Assertions.assertEquals(retrieve.getRecipeId(), saved.getRecipeId());
+    Assertions.assertEquals(retrieve.getUserId(), saved.getUserId());
+    Assertions.assertEquals(retrieve.getContent(), saved.getContent());
+    Assertions.assertEquals(retrieve.getLevel(), saved.getLevel());
+    if (retrieve.getLevel() == 0) {
+      Assertions.assertNull(retrieve.getParentCommentId());
+      Assertions.assertNull(saved.getParent());
+    } else {
+      Assertions.assertEquals(retrieve.getParentCommentId(), saved.getParent().getId());
+    }
+    Assertions.assertEquals(retrieve.getSort(), saved.getSort());
+    Assertions.assertEquals(retrieve.getScore(), saved.getScore());
+    Assertions.assertEquals(retrieve.getPhotoFileId(), saved.getPhotoFileId());
   }
 }

--- a/src/test/java/com/hongdaestudy/recipebackend/config/TestConfig.java
+++ b/src/test/java/com/hongdaestudy/recipebackend/config/TestConfig.java
@@ -1,0 +1,20 @@
+package com.hongdaestudy.recipebackend.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@TestConfiguration
+public class TestConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}


### PR DESCRIPTION
[comment]: <> "PR 제목은 다음과 같은 형태로 작성하고, 리뷰어에는 팀원 전체를 할당합니다."
[comment]: <> "{Jira-Issue-number} {한 줄 축약 내용 또는 티켓 제목 원형 그대로 이용}"




## 작업 개요
- 댓글 리스트 조회 API 구현

<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->



## 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경



## 작업 상세 내용
레시피 댓글 리스트 조회 기능 추가
댓글 등록시 부모 댓글 존재 여부 확인 함수 추가
<!--
  ex) 네 발 짐승 클래스에 `크앙` 함수 추가
-->



## 생각해볼 문제
#### Comment 객체 사용의 범위
- 댓글리스트 조회시,  repository 반환값 DTO 객체를 활용함.(의존성)

#### 에러 코드 생성 규칙

<!--
  ex) wav 파일을 매번 입력하기 귀찮겠다.
-->



## 완료한 테스트
댓글 리스트 조회 repository 정상적으로 동작하는지 확인
<!--
  ex) 로그인 API가 정상적으로 동작하는지 확인
-->
