### PR TITLE
BE-6 feat: 로그인 API 구현

### DIFF
--- a/src/main/java/com/hongdaestudy/recipebackend/config/error/ErrorCode.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/config/error/ErrorCode.java
@@ -2,7 +2,8 @@ package com.hongdaestudy.recipebackend.config.error;
 
 public enum ErrorCode {
     HANDLE_ACCESS_DENIED(403, "C_001", "권한이 없습니다."),
-    MEMBER_NOT_FOUND(400, "C_002", "사용자 정보를 찾을 수 없습니다.");
+    MEMBER_NOT_FOUND(400, "C_002", "사용자 정보를 찾을 수 없습니다."),
+    ACCESS_TOKEN_EXPIRED(400, "C_003", "토큰이 만료되었습니다.");
 
     private final String code;
     private final String message;

--- a/src/main/java/com/hongdaestudy/recipebackend/config/security/JwtFilter.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/config/security/JwtFilter.java
@@ -39,6 +39,10 @@ public class JwtFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
         } catch (ExpiredJwtException e) {
             ErrorResponse res = ErrorResponse.of(ErrorCode.ACCESS_TOKEN_EXPIRED);
+
+            response.setStatus(401);
+            response.setContentType("application/json");
+            response.setCharacterEncoding("utf-8");
             response.getWriter().write(new ObjectMapper().writeValueAsString(res));
             response.getWriter().flush();
         }

--- a/src/main/java/com/hongdaestudy/recipebackend/config/security/JwtFilter.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/config/security/JwtFilter.java
@@ -1,0 +1,47 @@
+package com.hongdaestudy.recipebackend.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hongdaestudy.recipebackend.config.error.ErrorCode;
+import com.hongdaestudy.recipebackend.config.error.ErrorResponse;
+import io.jsonwebtoken.ExpiredJwtException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    // Request로 들어오는 JwtToken의 유효성을 검증(jwtTokenProvider.validateToken)하는 filter을 filter chain에 등록한다.
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String path = request.getServletPath();
+
+            if (!path.startsWith("/api/auth/refresh")) {
+                String token = jwtTokenProvider.resolveToken(request);
+                if(token != null && jwtTokenProvider.validateToken(token)) {
+                    Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            }
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            ErrorResponse res = ErrorResponse.of(ErrorCode.ACCESS_TOKEN_EXPIRED);
+            response.getWriter().write(new ObjectMapper().writeValueAsString(res));
+            response.getWriter().flush();
+        }
+
+    }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/config/security/JwtTokenGenerator.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/config/security/JwtTokenGenerator.java
@@ -33,8 +33,13 @@ public class JwtTokenGenerator {
 
     public Tokens create(User user, UserProfile userProfile) {
         long nowInMilliseconds = new Date().getTime();
-        String accessToken = createAccessToken(String.valueOf(user.getId()), String.valueOf(userProfile.getId()), "ROLE_USER", new Date(nowInMilliseconds + accessTokenValidSeconds * 1000));
+        String accessToken = createAccessToken(String.valueOf(user.getId()),
+                String.valueOf(userProfile.getId()),
+                user.getEmail(),
+                "ROLE_USER",
+                new Date(nowInMilliseconds + accessTokenValidSeconds * 1000));
         String refreshToken = createRefreshToken(new Date(nowInMilliseconds + refreshTokenValidSeconds * 1000));
+        bearerTokenRepository.deleteAllByUserId(user.getId());
         bearerTokenRepository.save(new BearerToken(user.getId(), userProfile.getId(), refreshToken, accessToken));
         return new Tokens(accessToken, refreshToken);
     }
@@ -43,14 +48,19 @@ public class JwtTokenGenerator {
         BearerToken token = bearerTokenRepository.findByAccessToken(accessToken)
                 .orElseThrow(() -> new UserTokenNotFoundException("accessToken not found. token : " + accessToken));
         long nowInMilliseconds = new Date().getTime();
-        String changedAccessToken = createAccessToken(String.valueOf(user.getId()), String.valueOf(profile.getId()), "ROLE_USER", new Date(nowInMilliseconds + accessTokenValidSeconds * 1000));
+        String changedAccessToken = createAccessToken(String.valueOf(user.getId()),
+                String.valueOf(profile.getId()),
+                user.getEmail(),
+                "ROLE_USER",
+                new Date(nowInMilliseconds + accessTokenValidSeconds * 1000));
         token.exchangeAccessToken(changedAccessToken);
         bearerTokenRepository.save(token);
         return new Tokens(changedAccessToken, token.getRefreshToken());
     }
 
-    private String createAccessToken(String userId, String userProfileId, String role, Date expiry) {
+    private String createAccessToken(String userId, String userProfileId, String email, String role, Date expiry) {
         Claims claims = Jwts.claims().setSubject(userId).setExpiration(expiry).setIssuedAt(new Date());
+        claims.put("email", email);
         claims.put("role", role);
         claims.put("userProfileId", userProfileId);
         return Jwts.builder()

--- a/src/main/java/com/hongdaestudy/recipebackend/config/security/JwtTokenProvider.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/config/security/JwtTokenProvider.java
@@ -1,23 +1,28 @@
 package com.hongdaestudy.recipebackend.config.security;
 
+import com.hongdaestudy.recipebackend.user.application.CustomUserDetailService;
 import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
-import java.util.Base64;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
-public class JwtTokenProvider { // JWT 토큰 생성 및 검증 모듈
+public class JwtTokenProvider { // JWT 토큰 검증 모듈
+
+    private final CustomUserDetailService customUserDetailService;
 
     @Value("${jwt.secret}")
     private String secretKey;
@@ -30,6 +35,21 @@ public class JwtTokenProvider { // JWT 토큰 생성 및 검증 모듈
     // Request의 Header에서 token파싱
     public String resolveToken(HttpServletRequest request) {
         return request.getHeader("Authorization");
+    }
+
+    public Claims decode(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    // Jwt 토큰으로 인증 정보를 조회
+    public Authentication getAuthentication(String token) {
+        Claims claims = decode(token.substring("Bearer ".length()));
+        UserDetails userDetails = customUserDetailService.loadUserByUsername(String.valueOf(claims.get("email")));
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 
     // Jwt 토큰의 유효성 + 만료일자 확인

--- a/src/main/java/com/hongdaestudy/recipebackend/config/security/JwtTokenProvider.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/config/security/JwtTokenProvider.java
@@ -54,11 +54,7 @@ public class JwtTokenProvider { // JWT 토큰 검증 모듈
 
     // Jwt 토큰의 유효성 + 만료일자 확인
     public boolean validateToken(String jwtToken) {
-        try{
-            Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(jwtToken.substring("Bearer ".length()));
-            return !claims.getBody().getExpiration().before(new Date());// 만료시간이 현재시간보다 전인지 확인
-        } catch (Exception e) {
-            return false;
-        }
+        Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(jwtToken.substring("Bearer ".length()));
+        return !claims.getBody().getExpiration().before(new Date());// 만료시간이 현재시간보다 전인지 확인
     }
 }

--- a/src/main/java/com/hongdaestudy/recipebackend/config/security/SecurityConfig.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/config/security/SecurityConfig.java
@@ -8,12 +8,13 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
-
     private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final JwtTokenProvider jwtTokenProvider;
 
     protected void configure(HttpSecurity http) throws Exception {
         http
@@ -27,8 +28,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .authenticationEntryPoint(authenticationEntryPoint)
                 .and()
                     .authorizeRequests()
-                    .antMatchers("/", "/**").permitAll()
-                    .anyRequest().permitAll();
+                    .antMatchers("/api/auth/**").permitAll()
+                    .anyRequest().hasRole("USER")
+                .and()
+                .addFilterBefore(new JwtFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
     }
 
     @Bean

--- a/src/main/java/com/hongdaestudy/recipebackend/user/application/CustomUserDetailService.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/application/CustomUserDetailService.java
@@ -1,0 +1,37 @@
+package com.hongdaestudy.recipebackend.user.application;
+
+import com.hongdaestudy.recipebackend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        List<GrantedAuthority> roles = new ArrayList<>();
+        roles.add(new SimpleGrantedAuthority("ROLE_USER"));
+
+        return userRepository.findByEmail(email)
+                .map(m -> new AccountContext(m.getEmail(), m.getPassword(), roles))
+                .orElseThrow(() -> new UsernameNotFoundException("not found user"));
+    }
+
+    public static class AccountContext extends User {
+        public AccountContext(String username, String password, Collection<? extends GrantedAuthority> authorities) {
+            super(username, password, authorities);
+        }
+    }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/application/UserService.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/application/UserService.java
@@ -1,10 +1,15 @@
 package com.hongdaestudy.recipebackend.user.application;
 
 import com.hongdaestudy.recipebackend.config.security.JwtTokenGenerator;
+import com.hongdaestudy.recipebackend.config.security.JwtTokenProvider;
+import com.hongdaestudy.recipebackend.user.application.in.UserLoginCommand;
 import com.hongdaestudy.recipebackend.user.application.in.UserRegisterCommand;
 import com.hongdaestudy.recipebackend.user.application.out.UserRegisterCommandResult;
 import com.hongdaestudy.recipebackend.user.domain.*;
+import com.hongdaestudy.recipebackend.user.repository.BearerTokenRepository;
+import com.hongdaestudy.recipebackend.user.repository.UserProfileRepository;
 import com.hongdaestudy.recipebackend.user.repository.UserRepository;
+import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -15,7 +20,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
+    private final UserProfileRepository userProfileRepository;
     private final JwtTokenGenerator tokenGenerator;
+    private final JwtTokenProvider tokenProvider;
+    private final BearerTokenRepository bearerTokenRepository;
 
     @Transactional
     public UserRegisterCommandResult create(UserRegisterCommand request) {
@@ -24,5 +32,13 @@ public class UserService {
         userRepository.save(user);
         user = userRepository.findById(user.getId()).orElseThrow();
         return UserRegisterCommandResult.from(user, tokenGenerator.create(user, user.getUserProfile()));
+    }
+
+    @Transactional
+    public Tokens login(UserLoginCommand userLoginCommand) {
+        return userRepository.findByEmail(userLoginCommand.getEmail())
+                .filter(user -> passwordEncoder.matches(userLoginCommand.getPassword(), user.getPassword()))
+                .map(user -> tokenGenerator.create(user, user.getUserProfile()))
+                .orElseThrow(() -> new IllegalArgumentException("이메일 또는 비밀번호를 잘못 입력하셨습니다."));
     }
 }

--- a/src/main/java/com/hongdaestudy/recipebackend/user/application/in/RefreshTokenCommand.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/application/in/RefreshTokenCommand.java
@@ -1,0 +1,8 @@
+package com.hongdaestudy.recipebackend.user.application.in;
+
+import lombok.Getter;
+
+@Getter
+public class RefreshTokenCommand {
+    private String refreshToken;
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/application/in/UserLoginCommand.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/application/in/UserLoginCommand.java
@@ -1,0 +1,9 @@
+package com.hongdaestudy.recipebackend.user.application.in;
+
+import lombok.Getter;
+
+@Getter
+public class UserLoginCommand {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/presentation/UserCommandController.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/presentation/UserCommandController.java
@@ -1,6 +1,8 @@
 package com.hongdaestudy.recipebackend.user.presentation;
 
 import com.hongdaestudy.recipebackend.user.application.UserService;
+import com.hongdaestudy.recipebackend.user.application.in.RefreshTokenCommand;
+import com.hongdaestudy.recipebackend.user.application.in.UserLoginCommand;
 import com.hongdaestudy.recipebackend.user.application.in.UserRegisterCommand;
 import com.hongdaestudy.recipebackend.user.application.out.UserRegisterCommandResult;
 import com.hongdaestudy.recipebackend.user.domain.Tokens;
@@ -11,22 +13,26 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/auth")
 public class UserCommandController {
 
     private final UserService userService;
 
     @PostMapping("/join")
-    public ResponseEntity<UserRegisterCommandResult> create(@RequestBody UserRegisterCommand request) { ;
+    public ResponseEntity<UserRegisterCommandResult> create(@RequestBody UserRegisterCommand request) {
         return ResponseEntity.ok(userService.create(request));
     }
 
     @PostMapping("/login")
     public ResponseEntity<Tokens> login(@RequestBody UserLoginCommand userLoginCommand) {
         return ResponseEntity.ok(userService.login(userLoginCommand));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<Tokens> refresh(@RequestBody RefreshTokenCommand refreshTokenCommand) {
+        return ResponseEntity.ok(userService.refresh(refreshTokenCommand.getRefreshToken()));
     }
 }

--- a/src/main/java/com/hongdaestudy/recipebackend/user/presentation/UserCommandController.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/presentation/UserCommandController.java
@@ -25,4 +25,8 @@ public class UserCommandController {
         return ResponseEntity.ok(userService.create(request));
     }
 
+    @PostMapping("/login")
+    public ResponseEntity<Tokens> login(@RequestBody UserLoginCommand userLoginCommand) {
+        return ResponseEntity.ok(userService.login(userLoginCommand));
+    }
 }

--- a/src/main/java/com/hongdaestudy/recipebackend/user/repository/BearerTokenRepository.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/repository/BearerTokenRepository.java
@@ -2,10 +2,16 @@ package com.hongdaestudy.recipebackend.user.repository;
 
 import com.hongdaestudy.recipebackend.user.domain.BearerToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface BearerTokenRepository extends JpaRepository<BearerToken, Long> {
     Optional<BearerToken> findByRefreshToken(String refreshToken);
     Optional<BearerToken> findByAccessToken(String accessToken);
+
+    @Modifying
+    @Query(value = "delete from BearerToken rt where rt.userId = :userId")
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/hongdaestudy/recipebackend/user/repository/UserRepository.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/repository/UserRepository.java
@@ -6,9 +6,13 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
 
     @Modifying
     @Query(nativeQuery = true, value = "update user set user_profile_id = :userProfileId where user_id = :userId")
     void updateUserProfileId(Long userId, Long userProfileId);
+
+    Optional<User> findByEmail(String email);
 }


### PR DESCRIPTION
[comment]: <> "PR 제목은 다음과 같은 형태로 작성하고, 리뷰어에는 팀원 전체를 할당합니다."
[comment]: <> "{Jira-Issue-number} {한 줄 축약 내용 또는 티켓 제목 원형 그대로 이용}"




## 작업 개요

<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->

- 로그인 API 구현

## 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경



## 작업 상세 내용

<!--
  ex) 네 발 짐승 클래스에 `크앙` 함수 추가
-->

### Security단 토큰 인증 로직 구현

- SecurityConfig에 jwt token 인증 filter 추가

```java
protected void configure(HttpSecurity http) throws Exception {
    http
        @@ -27,8 +28,10 @@ protected void configure(HttpSecurity http) throws Exception {
        .authenticationEntryPoint(authenticationEntryPoint)
            .and()
            .authorizeRequests()
            .antMatchers("/", "/**").permitAll()
            .anyRequest().permitAll();
        .antMatchers("/api/auth/**").permitAll()
            .anyRequest().hasRole("USER")
            .and()
            .addFilterBefore(new JwtFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class); // 얘 추가
    }
```

- JwtFilter 구현

  - header로 전달받은 Jwt token의 유효성을 검증하는 필터

  - jwtTokenProvider를 주입받음

- jwtTokenProvider

  - 토큰을 decode하여 인증 정보 조회하는 로직 추가



### 로그인 로직 구현

- 로그인 요청 로직
  1. 클라이언트에서 id/pw body로 전달, 로그인 api 요청
  2. api서버에서는 id/pw 올바른지 체크
     - 올바르다면 access token, refresh token 생성하여 전달
     - 얘네들은 db에 저장



### refresh token 생성 로직 구현

- 액세스 토큰이 만료됐을 때 리프레시 토큰을 이용해서 다시 재생성 (/auth/refresh api 호출)



## 생각해볼 문제

<!--
  ex) wav 파일을 매번 입력하기 귀찮겠다.
-->

- refresh token을 재발급받을 때 레디스를 적용하고 싶다
- 테스트 코드 작성 미루는 중.... 죄송합니다



## 완료한 테스트

<!--
  ex) 로그인 API가 정상적으로 동작하는지 확인
-->

- 로그인했을 때 엑세스토큰/리프레시 토큰이 발급되는지 확인
- header에 액세스 토큰을 전달해 권한이 필요한 api에 접근할 수 있는지 확인
- 토큰이 만료됐을 경우 custom error를 반환하는지 확인
  - `ACCESS_TOKEN_EXPIRED(400, "C_003", "토큰이 만료되었습니다.");`
- refresh token을 통해 토큰이 재발급 되는지 확인
- 재발급한 토큰으로 권한이 필요한 api에 접근할 수 있는지 확인