### PR TITLE
BE-43 feat: 이메일 인증 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
 
+    implementation group: 'com.sun.mail', name: 'javax.mail', version: '1.6.2'
 
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/src/main/java/com/hongdaestudy/recipebackend/config/RedisConfig.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package com.hongdaestudy.recipebackend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/application/EmailSenderService.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/application/EmailSenderService.java
@@ -34,6 +34,20 @@ public class EmailSenderService {
 
         return EmailCodeResult.from(code);
     }
+
+    public Boolean verifyEmail(EmailCodeCommand req) {
+        try {
+            String email = redisUtil.getData(req.getCode());
+            if (email.equals(req.getEmail())) {
+                redisUtil.deleteData(req.getCode());
+                return true;
+            }
+        } catch (Exception e) {
+            return false;
+        }
+        return false;
+    }
+
     private static String createCode() {
         StringBuilder code = new StringBuilder();
         Random rnd = new Random();

--- a/src/main/java/com/hongdaestudy/recipebackend/user/application/EmailSenderService.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/application/EmailSenderService.java
@@ -1,0 +1,56 @@
+package com.hongdaestudy.recipebackend.user.application;
+
+import com.hongdaestudy.recipebackend.user.application.in.EmailCodeCommand;
+import com.hongdaestudy.recipebackend.user.application.in.EmailCommand;
+import com.hongdaestudy.recipebackend.user.application.out.EmailCodeResult;
+import com.hongdaestudy.recipebackend.util.RedisUtils;
+import io.netty.util.internal.StringUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class EmailSenderService {
+    private final JavaMailSender emailSender;
+    private final RedisUtils redisUtil;
+
+    public EmailCodeResult sendEmailMessage(EmailCommand email) {
+        String code = createCode();
+        redisUtil.setDataExpire(code, email.getEmail(),  60 * 30L);
+
+        log.debug("이메일 전송 중...");
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email.getEmail());
+        message.setSubject("회원가입 인증 메일입니다. ");
+        message.setText(code);
+        emailSender.send(message);
+        log.debug("이메일 전송 완료");
+
+        return EmailCodeResult.from(code);
+    }
+    private static String createCode() {
+        StringBuilder code = new StringBuilder();
+        Random rnd = new Random();
+        for (int i = 0; i < 7; i++) {
+            int rIndex = rnd.nextInt(3);
+            switch (rIndex) {
+                case 0:
+                    code.append((char) (rnd.nextInt(26) + 97));
+                    break;
+                case 1:
+                    code.append((char) (rnd.nextInt(26) + 65));
+                    break;
+                case 2:
+                    code.append((rnd.nextInt(10)));
+                    break;
+            }
+        }
+        return code.toString();
+    }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/application/in/EmailCodeCommand.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/application/in/EmailCodeCommand.java
@@ -1,0 +1,9 @@
+package com.hongdaestudy.recipebackend.user.application.in;
+
+import lombok.Getter;
+
+@Getter
+public class EmailCodeCommand {
+    private String email;
+    private String code;
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/application/in/EmailCommand.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/application/in/EmailCommand.java
@@ -1,0 +1,8 @@
+package com.hongdaestudy.recipebackend.user.application.in;
+
+import lombok.Getter;
+
+@Getter
+public class EmailCommand {
+    private String email;
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/application/out/EmailCodeResult.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/application/out/EmailCodeResult.java
@@ -1,0 +1,19 @@
+package com.hongdaestudy.recipebackend.user.application.out;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class EmailCodeResult {
+    private String code;
+
+    public EmailCodeResult(String code) {
+        this.code = code;
+    }
+
+    public static EmailCodeResult from(String verifyCode) {
+        return new EmailCodeResult(verifyCode);
+    }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/user/presentation/EmailCommandController.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/presentation/EmailCommandController.java
@@ -21,4 +21,9 @@ public class EmailCommandController {
     public ResponseEntity<EmailCodeResult> sendEmail(@RequestBody EmailCommand request) {
         return ResponseEntity.ok(emailSenderService.sendEmailMessage(request));
     }
+
+    @PostMapping("/verify-code")
+    public ResponseEntity<Boolean> verifyCode(@RequestBody EmailCodeCommand request) {
+        return ResponseEntity.ok(emailSenderService.verifyEmail(request));
+    }
 }

--- a/src/main/java/com/hongdaestudy/recipebackend/user/presentation/EmailCommandController.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/user/presentation/EmailCommandController.java
@@ -1,0 +1,24 @@
+package com.hongdaestudy.recipebackend.user.presentation;
+
+import com.hongdaestudy.recipebackend.user.application.EmailSenderService;
+import com.hongdaestudy.recipebackend.user.application.in.EmailCodeCommand;
+import com.hongdaestudy.recipebackend.user.application.in.EmailCommand;
+import com.hongdaestudy.recipebackend.user.application.out.EmailCodeResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class EmailCommandController {
+    private final EmailSenderService emailSenderService;
+
+    @PostMapping("/email-send")
+    public ResponseEntity<EmailCodeResult> sendEmail(@RequestBody EmailCommand request) {
+        return ResponseEntity.ok(emailSenderService.sendEmailMessage(request));
+    }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/util/RedisUtils.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/util/RedisUtils.java
@@ -1,0 +1,31 @@
+package com.hongdaestudy.recipebackend.util;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+@Component
+public class RedisUtils {
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    public String getData(String key) { // key를 통해 value(데이터)를 얻는다.
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public void setDataExpire(String key, String value, long duration) {
+        //  duration 동안 (key, value)를 저장한다.
+        redisTemplate.opsForValue().set(key, value,duration, TimeUnit.SECONDS);
+    }
+
+    public void deleteData(String key) {
+        // 데이터 삭제
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,6 +22,9 @@ spring:
         format_sql: true
     open-in-view: false
 
+  redis:
+    host: localhost
+    port: 6379
 logging.level:
   org.hibernate.SQL: debug
   org.hibernate.type: trace


### PR DESCRIPTION
[comment]: <> "PR 제목은 다음과 같은 형태로 작성하고, 리뷰어에는 팀원 전체를 할당합니다."
[comment]: <> "{Jira-Issue-number} {한 줄 축약 내용 또는 티켓 제목 원형 그대로 이용}"




## 작업 개요

<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->

- 이메일 인증 API 구현

## 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경



## 작업 상세 내용

<!--
  ex) 네 발 짐승 클래스에 `크앙` 함수 추가
-->

### 시나리오

1. 이메일 전송 API 요청 (email)
   - 요청받은 이메일 주소로 인증코드 전송
   - redis에 이메일과 인증코드 저장
     - {code, email}
2. 이메일 인증 API 요청 (email, code)
   -  redis에 code(key)로 email(value) 가져옴
   - redis에 저장된 email이(value) 요청한 email과 일치한지 확인
   - 맞다면 true반환 아니면 false 반환



## 생각해볼 문제

<!--
  ex) wav 파일을 매번 입력하기 귀찮겠다.
-->

- 메일 정보 yml에 저장해놔야하는데 이거 어떻게 할까요 (깃헙에 올리면 보안 이슈)

## 완료한 테스트

<!--
  ex) 로그인 API가 정상적으로 동작하는지 확인
-->

- 메일이 정상적으로 전송되는지 확인
- redis에 정상적으로 저장되는지 확인
- 인증로직이 정상적으로 동작하는지 확인