### PR TITLE
FE-50 레시피 파일 등록 로컬

### DIFF
--- a/src/main/java/com/hongdaestudy/recipebackend/file/application/RegisterFileService.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/file/application/RegisterFileService.java
@@ -1,0 +1,57 @@
+package com.hongdaestudy.recipebackend.file.application;
+
+
+import com.hongdaestudy.recipebackend.file.domain.Files;
+import com.hongdaestudy.recipebackend.file.domain.repository.FileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class RegisterFileService {
+  private final FileRepository fileRepository;
+
+
+  @Transactional
+  public long uploadFile(MultipartFile uploadFile) throws Exception {
+    String originalFileName = uploadFile.getOriginalFilename();    //오리지날 파일명
+    String extension = originalFileName.substring(originalFileName.lastIndexOf("."));    //파일 확장자
+    String savedFileName = UUID.randomUUID() + extension;    //저장될 파일 명
+
+    Files fileInfo = Files.create(originalFileName
+        , extension, "/Users/zion/IdeaProjects/upload/", uploadFile.getSize()
+    );
+    File destFile = new File("/Users/zion/IdeaProjects/upload/" + savedFileName);
+    uploadFile.transferTo(destFile);
+
+    return fileRepository.save(fileInfo).getId();
+
+  }
+
+  @Transactional
+  public List<Long> uploadFiles(MultipartFile[] files) throws Exception {
+    List<Long> savedList = new ArrayList<>();
+    for (MultipartFile file : files) {
+      String originalFileName = file.getOriginalFilename();    //오리지날 파일명
+      String extension = originalFileName.substring(originalFileName.lastIndexOf("."));    //파일 확장자
+      String savedFileName = UUID.randomUUID() + extension;    //저장될 파일 명
+
+      //TODO 디렉토리 구조
+      Files fileInfo = Files.create(originalFileName
+          , extension, "/Users/zion/IdeaProjects/upload/", file.getSize()
+      );
+      File saveFile = new File("/Users/zion/IdeaProjects/upload/" + savedFileName);
+      file.transferTo(saveFile);
+
+      savedList.add(fileRepository.save(fileInfo).getId());
+    }
+    return savedList;
+  }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/file/domain/Files.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/file/domain/Files.java
@@ -1,0 +1,46 @@
+package com.hongdaestudy.recipebackend.file.domain;
+
+import com.hongdaestudy.recipebackend.common.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.persistence.*;
+
+@Table(name = "file")
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@ToString
+public class Files extends BaseTimeEntity {
+
+  //TODO 테이블 수정 - file_cnt, type,,,
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "file_id")
+  private Long id;
+
+  private String fileName;
+
+  private String originalName;
+
+  @Column(name = "file_ext")
+  private String extension;
+
+  private String filePath;
+
+  private long fileSize;
+
+  public static Files create(String originalName, String extension, String filePath, long fileSize) {
+
+    Files file = new Files();
+    file.fileName = originalName;
+    file.originalName = originalName;
+    file.extension = extension;
+    file.filePath = filePath;
+    file.fileSize = fileSize;
+
+    return file;
+  }
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/file/domain/repository/FileRepository.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/file/domain/repository/FileRepository.java
@@ -1,0 +1,8 @@
+package com.hongdaestudy.recipebackend.file.domain.repository;
+
+import com.hongdaestudy.recipebackend.file.domain.Files;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileRepository extends JpaRepository<Files, Long> {
+
+}

--- a/src/main/java/com/hongdaestudy/recipebackend/recipe/application/RegisterRecipeService.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/recipe/application/RegisterRecipeService.java
@@ -35,17 +35,17 @@ public class RegisterRecipeService {
 
   private Recipe from(RegisterRecipeCommand registerRecipeCommand) {
     List<RecipeStep> recipeSteps = registerRecipeCommand.getRecipeSteps().stream()
-            .map(recipeStepCommand -> RecipeStep.create(
-                    recipeStepCommand.getDescription(),
-                    recipeStepCommand.getPhotoFileId(),
-                    recipeStepCommand.getSort()))
-            .collect(Collectors.toList());
+        .map(recipeStepCommand -> RecipeStep.create(
+            recipeStepCommand.getDescription(),
+            recipeStepCommand.getPhotoFileId(),
+            recipeStepCommand.getSort()))
+        .collect(Collectors.toList());
 
     List<RecipeTag> recipeTags = registerRecipeCommand.getRecipeTags().stream()
-            .map(recipeTagCommand -> RecipeTag.create(
-                        recipeTagCommand.getName(),
-                        recipeTagCommand.getSort()))
-            .collect(Collectors.toList());
+        .map(recipeTagCommand -> RecipeTag.create(
+            recipeTagCommand.getName(),
+            recipeTagCommand.getSort()))
+        .collect(Collectors.toList());
 
     RecipeInformation recipeInformation = RecipeInformation.create(
         registerRecipeCommand.getInformation().getServingCount(),
@@ -56,9 +56,10 @@ public class RegisterRecipeService {
         registerRecipeCommand.getMemberId(),
         registerRecipeCommand.getTitle(),
         registerRecipeCommand.getDescription(),
-        registerRecipeCommand.getVideoFileId(),
+        registerRecipeCommand.getVideoUrl(),
         recipeInformation,
-        registerRecipeCommand.getCompletionPhotoFileId(),
+        registerRecipeCommand.getMainPhotoFileId(),
+        registerRecipeCommand.getCompletionPhotoFileId().get(0), //TODO 다중파일 데이터.. 파일 테이블 구조 변경?
         registerRecipeCommand.getTip(),
         recipeSteps,
         recipeTags,

--- a/src/main/java/com/hongdaestudy/recipebackend/recipe/application/in/RegisterRecipeCommand.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/recipe/application/in/RegisterRecipeCommand.java
@@ -15,9 +15,10 @@ public class RegisterRecipeCommand {
   private List<RegisterRecipeStepCommand> recipeSteps;
   private String title;
   private String description;
-  private Long videoFileId;
+  private String videoUrl;
   private RegisterRecipeInformationCommand information;
-  private Long completionPhotoFileId;
+  private Long mainPhotoFileId;
+  private List<Long> completionPhotoFileId; //TODO 추후 변경
   private String tip;
   private List<RegisterRecipeTagCommand> recipeTags;
   private RecipeStatus status;

--- a/src/main/java/com/hongdaestudy/recipebackend/recipe/domain/Recipe.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/recipe/domain/Recipe.java
@@ -35,11 +35,12 @@ public class Recipe extends BaseTimeEntity {
 
   private String description;
 
-  private Long videoFileId;
+  private String videoUrl;
 
   @Embedded
   private RecipeInformation information;
-
+  
+  private Long mainPhotoFileId;
   private Long completionPhotoFileId;
 
   private String tip;
@@ -78,8 +79,9 @@ public class Recipe extends BaseTimeEntity {
       Long memberId,
       String title,
       String description,
-      Long videoFileId,
+      String videoUrl,
       RecipeInformation information,
+      Long mainPhotoFileId,
       Long completionPhotoFileId,
       String tip,
       List<RecipeStep> recipeSteps,
@@ -90,8 +92,9 @@ public class Recipe extends BaseTimeEntity {
     recipe.memberId = memberId;
     recipe.title = title;
     recipe.description = description;
-    recipe.videoFileId = videoFileId;
+    recipe.videoUrl = videoUrl;
     recipe.information = information;
+    recipe.mainPhotoFileId = mainPhotoFileId;
     recipe.completionPhotoFileId = completionPhotoFileId;
     recipe.tip = tip;
     recipe.status = status;

--- a/src/main/java/com/hongdaestudy/recipebackend/recipe/domain/repository/RecipeRepositoryImpl.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/recipe/domain/repository/RecipeRepositoryImpl.java
@@ -28,7 +28,7 @@ public class RecipeRepositoryImpl implements RecipeRepositoryCustom {
         //, recipe.recipeSteps
         , recipe.title
         , recipe.description
-        , recipe.videoFileId
+        , recipe.videoUrl
         , recipe.information.servingCount
         , recipe.information.cookingTime
         , recipe.information.difficultyLevel

--- a/src/main/java/com/hongdaestudy/recipebackend/recipe/presentation/RecipeCommandController.java
+++ b/src/main/java/com/hongdaestudy/recipebackend/recipe/presentation/RecipeCommandController.java
@@ -1,5 +1,6 @@
 package com.hongdaestudy.recipebackend.recipe.presentation;
 
+import com.hongdaestudy.recipebackend.file.application.RegisterFileService;
 import com.hongdaestudy.recipebackend.recipe.application.RegisterRecipeService;
 import com.hongdaestudy.recipebackend.recipe.application.RetrieveRecipeService;
 import com.hongdaestudy.recipebackend.recipe.application.in.RegisterRecipeCommand;
@@ -8,10 +9,11 @@ import com.hongdaestudy.recipebackend.recipe.application.out.RegisterRecipeComma
 import com.hongdaestudy.recipebackend.recipe.application.out.RetrieveRecipeCommandResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.stream.IntStream;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,9 +22,26 @@ public class RecipeCommandController {
   private final RegisterRecipeService registerRecipeService;
   private final RetrieveRecipeService retrieveRecipeService;
 
-  @PostMapping("/recipes")
-  public ResponseEntity<RegisterRecipeCommandResult> registerRecipe(@RequestBody RegisterRecipeCommand registerRecipeCommand) {
+  private final RegisterFileService registerFileService;
 
+  @PostMapping("/recipes")
+  public ResponseEntity<RegisterRecipeCommandResult> registerRecipe(
+      @RequestPart("mainPhotoFile") MultipartFile mainPhotoFile
+      , @RequestPart("completionPhotoFileList") MultipartFile[] completionPhotoFileList
+      , @RequestPart("stepPhotoFileList") MultipartFile[] stepPhotoFileList
+      , @RequestPart("recipe") RegisterRecipeCommand registerRecipeCommand) {
+
+    try {
+      registerRecipeCommand.setMainPhotoFileId(registerFileService.uploadFile(mainPhotoFile));
+      registerRecipeCommand.setCompletionPhotoFileId(registerFileService.uploadFiles(completionPhotoFileList));
+      List<Long> stepFileList = registerFileService.uploadFiles(stepPhotoFileList);
+
+      IntStream.range(0, registerRecipeCommand.getRecipeSteps().size())
+          .forEach(index -> registerRecipeCommand.getRecipeSteps().get(index).setPhotoFileId(stepFileList.get(index)));
+
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
     RegisterRecipeCommandResult result = registerRecipeService.registerRecipe(registerRecipeCommand);
 
     return ResponseEntity.ok(result);


### PR DESCRIPTION
[comment]: <> "PR 제목은 다음과 같은 형태로 작성하고, 리뷰어에는 팀원 전체를 할당합니다."
[comment]: <> "{Jira-Issue-number} {한 줄 축약 내용 또는 티켓 제목 원형 그대로 이용}"




## 작업 개요

레시피 등록시 사진 로컬 업로드 기능
<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->



## 작업 분류

- [ ] 버그 수정
- [X] 신규 기능
- [ ] 프로젝트 구조 변경



## 작업 상세 내용
- 메인사진
- 완성사진 
- 요리순서 사진 
<!--
  ex) 네 발 짐승 클래스에 `크앙` 함수 추가
-->



## 생각해볼 문제

- 다중 파일 업로드시, 레시피 테이블에 저장할 대표 파일 ID
  +  group_id 추가
  +  file_cnt 추가

- 파일 저장시, 폴더 구조
  + 메인/완성/요리순서
<!--
  ex) wav 파일을 매번 입력하기 귀찮겠다.
-->



## 완료한 테스트

<!--
  ex) 로그인 API가 정상적으로 동작하는지 확인
-->
